### PR TITLE
Expanded options for required validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Multilang has some validation features:
     multilang :title, :required => true #define requirement validator for all available_locales
     multilang :title, :required => 1 #define requirement validator for 1 locale
     multilang :title, :required => [:en, :es] #define requirement validator for specific locales
-    multilang :title, :required => true #define requirement validator for all available_locales
     multilang :title, :format => /regexp/ #define validates_format_of validator
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ The value from "any" method returns value for I18n.current_locale or, if value i
 Multilang has some validation features:
 
     multilang :title, :length => 100  #define maximal length validator
-    multilang :title, :required => true #define requirement validator 
+    multilang :title, :required => true #define requirement validator for all available_locales
+    multilang :title, :required => 1 #define requirement validator for 1 locale
+    multilang :title, :required => [:en, :es] #define requirement validator for specific locales
+    multilang :title, :required => true #define requirement validator for all available_locales
     multilang :title, :format => /regexp/ #define validates_format_of validator
 
 ## Tests

--- a/lib/multilang-hstore.rb
+++ b/lib/multilang-hstore.rb
@@ -2,6 +2,7 @@ require 'multilang-hstore/version'
 require 'multilang-hstore/exceptions'
 require 'multilang-hstore/translation_proxy'
 require 'multilang-hstore/translation_keeper'
+require 'multilang-hstore/validators/translation_count_validator'
 require 'multilang-hstore/active_record_extensions'
 
 module Multilang

--- a/lib/multilang-hstore/active_record_extensions.rb
+++ b/lib/multilang-hstore/active_record_extensions.rb
@@ -43,6 +43,12 @@ module Multilang
             serialize "#{attribute}", ActiveRecord::Coders::Hstore
           end if defined?(ActiveRecord::Coders::Hstore)
 
+          if options[:required].is_a? Numeric
+            module_eval do
+              validates "#{attribute}_before_type_cast", :'multilang/validators/translation_count' => {min: options[:required]}
+            end
+          end
+
           I18n.available_locales.each do |locale|
 
             define_method "#{attribute}_#{locale}" do
@@ -59,7 +65,7 @@ module Multilang
             end
 
             # attribute presence validator
-            if options[:required]
+            if options[:required] == true or locale_required?(options[:required], locale)
               module_eval do
                 validates_presence_of "#{attribute}_#{locale}"
               end
@@ -94,6 +100,10 @@ module Multilang
           instance_variable_get "@multilang_attribute_#{attribute}"
         end unless method_defined? :multilang_translation_keeper
 
+      end
+
+      def locale_required? options_required, locale
+        options_required.is_a? Array and options_required.map(&:to_s).include?(locale.to_s)
       end
 
     end

--- a/lib/multilang-hstore/validators/translation_count_validator.rb
+++ b/lib/multilang-hstore/validators/translation_count_validator.rb
@@ -1,0 +1,14 @@
+module Multilang
+  module Validators
+    class TranslationCountValidator < ActiveModel::EachValidator
+
+      def validate_each(record, attribute, value)
+        count = record.send("#{attribute}").reject{|l,v| v.blank?}.size
+        if count < options[:min]
+          record.errors[:attribute] << (options[:message] || "has insufficient translations defined")
+        end
+      end
+
+    end
+  end
+end

--- a/spec/multilang_spec.rb
+++ b/spec/multilang_spec.rb
@@ -280,4 +280,43 @@ describe Multilang do
     query_post.title.should == "English USA"
   end
 
+  it "should be valid when required specified translations are present" do
+    post = TacoPost.new
+    post.title = {lv: "Lv", ru: "Ru"}
+    post.valid?
+    post.should be_valid
+
+    I18n.locale = :nl
+    post.title = "Nl"
+    post.valid?
+    post.should be_valid
+  end
+
+  it "should be invalid when required specified translations are not present" do
+    post = TacoPost.new
+    I18n.locale = :es
+    post.title = {lv: "Latvian"}
+    post.valid?
+    post.should have(1).errors
+  end
+
+  it "should be valid when require number validation is met" do
+    post = SloppyPost.new
+    I18n.locale = :es
+    post.title = {en: "English"}
+    post.valid?
+    post.should be_valid
+
+    post.title = "In Spanish"
+    post.valid?
+    post.should be_valid
+  end
+
+  it "should be invalid when require number validation is not met" do
+    post = SloppyPost.new
+    I18n.locale = :es
+    post.valid?
+    post.should have(1).errors
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,3 +50,13 @@ class NamedPost < ActiveRecord::Base
   self.table_name = 'named_posts'
   multilang :title
 end
+
+class TacoPost < ActiveRecord::Base
+  self.table_name = 'named_posts'
+  multilang :title, required: [:lv, :ru]
+end
+
+class SloppyPost < ActiveRecord::Base
+  self.table_name = 'named_posts'
+  multilang :title, required: 1
+end


### PR DESCRIPTION
The current implementation of the `required` validation option requires a translation present for all `available_locales`.

I have a use case where the translations are optional, but at least one translation is not. This pull requests implements 2 ways to achieve this, by passing other values than `true` to `required`. Passing `true` still works as before.

Examples:
```ruby
multilang :title, :required => 1 #define requirement validator for 1 locale
multilang :title, :required => [:en, :es] #define requirement validator for specific locales
multilang :title, :required => true #define requirement validator for all available_locales
```