### PR TITLE
 Fix. MultilangTranslationProxy assignment.

### DIFF
--- a/lib/multilang-hstore/translation_keeper.rb
+++ b/lib/multilang-hstore/translation_keeper.rb
@@ -32,7 +32,9 @@ module Multilang
     def update(value)
       if value.is_a?(Hash)
         clear
-        value.each{|k, v| write(k, v)}
+        value.each { |k, v| write(k, v) }
+      elsif value.is_a?(MultilangTranslationProxy)
+        update(value.translation.translations)
       elsif value.is_a?(String)
         write(actual_locale, value)
       end


### PR DESCRIPTION
Fix the bug of assignment a MultilangTranslationProxy to multilang attribute.

It can fix this case.
```
class City < ActiveRecord::Base
  multilang :name
end

serialized_record = YAML.dump city.name
city.name = YAML.load serialized_record
```

serialized_record stores the serialized instance of MultilangTranslationProxy.
YAML.load return the instance of MultilangTranslationProxy.
After the evaluation of 'city.name = YAML.load serialized_record' city.name will become a blank string because `city.name=` can't take a argument with MultilangTranslationProxy type.