### PR TITLE
Add more options to lenght validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ We're assuming here you want a Post model with some multilang attributes, as out
 or
 
     class Post < ActiveRecord::Base
-      multilang :title, :description, :required => true, :length => 100
+      multilang :title, :description, 
+        :required => true,
+        :length => { :maximum=>100, :minimum=>2 }
     end
 
 The multilang translations are stored in the same model attributes (eg. title):
@@ -116,7 +118,10 @@ The value from "any" method returns value for I18n.current_locale or, if value i
 
 Multilang has some validation features:
 
-    multilang :title, :length => 100  #define maximal length validator
+    multilang :title, :length => 100  #define maximum length validator
+    multilang :title, :length => {:minimum=> 2,:maximum=>100}  #define min/max length validator
+    multilang :title, :length => {:within=>2..100}  #define min/max length validator
+    multilang :title, :length => {:is=> 10} #length is exactly 10
     multilang :title, :required => true #define requirement validator for all available_locales
     multilang :title, :required => 1 #define requirement validator for 1 locale
     multilang :title, :required => [:en, :es] #define requirement validator for specific locales

--- a/lib/multilang-hstore/active_record_extensions.rb
+++ b/lib/multilang-hstore/active_record_extensions.rb
@@ -74,7 +74,8 @@ module Multilang
             #attribute maximal length validator
             if options[:length]
               module_eval do
-                validates_length_of "#{attribute}_#{locale}", :maximum => options[:length]
+                validates_length_of "#{attribute}_#{locale}",
+                  ( options[:length].is_a?(Hash) ? options[:length] : {:maximum=>options[:length]} )
               end
             end
 


### PR DESCRIPTION
PROBLEM: Current options for length are not enough. Maybe you need to
restrict the minimum lenght or be a exact value

SOLUTION: add all the options of rails length validator, not just
maximum. But keep the old behaviour for retrocompatybility if just a
number is passed to length.

```
  Examples:
    multilang :title, :length => 100  #define maximum length validator
    multilang :title, :length => {:maximum=>100}  #define maximum length validator
    multilang :title, :length => {:minimum=> 2,:maximum=>100}  #define min/max length validator
    multilang :title, :length => {:within=>2..100}  #define min/max length validator
    multilang :title, :length => {:is=> 10} #length is exactly 10
```
