### PR TITLE
Enable getting an i18n error message with key

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ Multilang has some validation features:
     multilang :title, :required => [:en, :es] #define requirement validator for specific locales
     multilang :title, :format => /regexp/ #define validates_format_of validator
 
+## Error messages
+
+To get a custom message you will need to use one of this solutions:
+
+1. Use the message in the declaration
+
+    multilang :title, :required => 1, :message => 'Not enough translations'
+
+2. Write a new key in your translations file. Ex:
+
+    [config/locales/yourtranslationsfile.yml]
+    errors:
+      messages:
+        insufficient-translations:
+          one: 'We need at least one tranlation.'
+          other: 'We need at least %{count} tranlations.'
+
 ## Tests
 
 Test runs using a temporary database in your local PostgreSQL server:

--- a/lib/multilang-hstore/validators/translation_count_validator.rb
+++ b/lib/multilang-hstore/validators/translation_count_validator.rb
@@ -5,7 +5,11 @@ module Multilang
       def validate_each(record, attribute, value)
         count = record.send("#{attribute}").reject{|l,v| v.blank?}.size
         if count < options[:min]
-          record.errors[:attribute] << (options[:message] || "has insufficient translations defined")
+          record.errors[attribute.sub('_before_type_cast','')] <<
+            (options[:message] ||
+             I18n.t('errors.messages.insufficient-translations',
+                                         count: options[:min] )
+            )
         end
       end
 


### PR DESCRIPTION
PROBLEM: Currently the message has to be included in the same
declaration with:

```
  multilang :title, :required => 2,
    message: 'Insuficientes traducciones'
```

It would be better to have a default error key in the translations file.

SOLUTION: Add I18n key by default. The developer will need to add
something like this to his translations file.

```
  errors:
    messages:
      insufficient-translations:
        one: 'We need at least one tranlation.'
        other: 'We need at least %{count} tranlations.'
```
