### PR TITLE
Added squish option to attributes

### DIFF
--- a/lib/multilang-hstore/active_record_extensions.rb
+++ b/lib/multilang-hstore/active_record_extensions.rb
@@ -13,25 +13,26 @@ module Multilang
           :required => false,
           :length => nil,
           :accessible => false,
-          :format => nil
+          :format => nil,
+          :squish => false
         }.merge(args.extract_options!)
 
-        options.assert_valid_keys([:required, :length, :accessible, :format, :nil])
-
+        options.assert_valid_keys([:required, :length, :accessible, :format, :squish, :nil])
+       
         define_translation_base!
-
+         
         args.each do |attribute|
 
           define_method attribute do
-            multilang_translation_keeper(attribute).value
+            multilang_translation_keeper(attribute, options[:squish]).value
           end
 
           define_method "#{attribute}=" do |value|
-            multilang_translation_keeper(attribute).update(value)
+            multilang_translation_keeper(attribute, options[:squish]).update(value)
           end
 
           define_method "#{attribute}_before_type_cast" do
-            multilang_translation_keeper(attribute).translations
+            multilang_translation_keeper(attribute, options[:squish]).translations
           end
 
           #attribute accessibility for mass assignment
@@ -52,11 +53,11 @@ module Multilang
           I18n.available_locales.each do |locale|
 
             define_method "#{attribute}_#{locale}" do
-              multilang_translation_keeper(attribute)[locale]
+              multilang_translation_keeper(attribute, options[:squish])[locale]
             end
 
             define_method "#{attribute}_#{locale}=" do |value|
-              multilang_translation_keeper(attribute)[locale] = value
+              multilang_translation_keeper(attribute, options[:squish])[locale] = value
             end
 
             # locale based attribute accessibility for mass assignment
@@ -92,14 +93,14 @@ module Multilang
       private
 
       def define_translation_base!
-
-        define_method "multilang_translation_keeper" do |attribute|
+        
+        define_method "multilang_translation_keeper" do |attribute, squish|
           unless instance_variable_defined?("@multilang_attribute_#{attribute}")
-            instance_variable_set("@multilang_attribute_#{attribute}", MultilangTranslationKeeper.new(self, attribute))
+            instance_variable_set("@multilang_attribute_#{attribute}", MultilangTranslationKeeper.new(self, attribute, squish))
           end
           instance_variable_get "@multilang_attribute_#{attribute}"
         end unless method_defined? :multilang_translation_keeper
-
+        
       end
 
       def locale_required? options_required, locale

--- a/lib/multilang-hstore/translation_keeper.rb
+++ b/lib/multilang-hstore/translation_keeper.rb
@@ -4,11 +4,13 @@ module Multilang
     attr_reader :model
     attr_reader :attribute
     attr_reader :translations
+    attr_reader :squish
 
-    def initialize(model, attribute)
+    def initialize(model, attribute, squish)
       @model = model
       @attribute = attribute
       @translations = {}
+      @squish = squish
       load!
     end
 
@@ -69,11 +71,11 @@ module Multilang
     end
 
     def write(locale, value)
-      @translations[locale.to_s] = value
+      @translations[locale.to_s] = @squish == true ? value.squish! : value
     end
 
     def read(locale)
-      @translations.read(locale)
+      @squish == true ? @translations.read(locale).squish! : @translations.read(locale)
     end
 
     def raw_read(locale)

--- a/spec/multilang_spec.rb
+++ b/spec/multilang_spec.rb
@@ -319,4 +319,30 @@ describe Multilang do
     expect(post.errors.size).to be >= 1
   end
 
+  it "should squish attributes when option :squish is passed as true" do
+    post = SquishedPost.new
+    I18n.locale = :en
+    post.title = " foo   bar    \n   \t   boo"
+    post.title.should == "foo bar boo"
+    
+    post.title = {:en=>"English        USA", :es=>"Spanish           LAT"}
+    post.title.translation[:en].should == "English USA"
+    post.title.translation[:es].should == "Spanish LAT"
+  end
+  
+  it "should get unsquished attributes as squished when option :squish is passed as true" do
+    # Create record with unsquished title
+    post = NamedPost.new
+    post.name = "unsquished_record"
+    post.title = {en: " foo   bar    \n   \t   boo"}
+    post.save!
+    
+    # Get title from SquishedPost as squished
+    post = SquishedPost.where(name: 'unsquished_record').first
+    post.title.translation[:en].should == "foo bar boo"
+    
+    # Get title from NamedPost as unsquished
+    post = NamedPost.where(name: 'unsquished_record').first
+    post.title.translation[:en].should == " foo   bar    \n   \t   boo"
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,3 +68,8 @@ class SloppyPost < ActiveRecord::Base
   self.table_name = 'named_posts'
   multilang :title, required: 1
 end
+
+class SquishedPost < ActiveRecord::Base
+  self.table_name = 'named_posts'
+  multilang :title, squish: true
+end


### PR DESCRIPTION
I needed to sanitize my strings for each locale, which was difficult to implement at the model level.

That’s why I introduced an option called :squish at the multilang attribute level.  It squishes strings for all locales, when set to true for an attribute.